### PR TITLE
feat: Group-Permission Assignment Endpoints (#78)

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -27,6 +27,8 @@
    - [Get Group By ID](#get-group-by-id-endpoint)
    - [Update Group](#update-group-endpoint)
    - [Delete Group](#delete-group-endpoint)
+   - [Add Permission To Group](#add-permission-to-group-endpoint)
+   - [Remove Permission From Group](#remove-permission-from-group-endpoint)
 7. [Permission Management](#permission-management)
    - [Create Permission](#create-permission-endpoint)
    - [List Permissions](#list-permissions-endpoint)
@@ -1449,6 +1451,113 @@ No response body.
 
 ```bash
 curl -X DELETE http://localhost:8080/api/groups/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+### Add Permission To Group Endpoint
+
+#### Overview
+Assigns a permission to a group, granting all users in that group the specified permission. This enables flexible role-based access control by managing permissions at the group level.
+
+#### Endpoint Details
+
+**URL:** `POST /api/groups/:id/permissions`  
+**Content-Type:** `application/json`  
+**Authentication:** Required (JWT Bearer token)  
+**Required Permission:** `groups:write`
+
+#### URL Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | UUID | **Yes** | Group ID |
+
+#### Request Schema
+
+```json
+{
+  "permission_id": "perm-uuid-123"
+}
+```
+
+#### Field Descriptions
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `permission_id` | UUID | **Yes** | Permission ID to assign to the group |
+
+#### Response
+
+**Success Response (200 OK):**
+```json
+{
+  "message": "Permission added to group successfully"
+}
+```
+
+**Error Responses:**
+
+| Status Code | Description | Response Body |
+|-------------|-------------|---------------|
+| 400 Bad Request | Invalid input data | `{"error": "Invalid request format"}` / `{"error": "Permission ID is required"}` |
+| 401 Unauthorized | Missing or invalid token | `{"error": "Unauthorized"}` |
+| 403 Forbidden | Insufficient permissions | `{"error": "Insufficient permissions"}` |
+| 404 Not Found | Group or permission not found | `{"error": "Group not found"}` / `{"error": "Permission not found"}` |
+| 409 Conflict | Permission already assigned | `{"error": "Permission already assigned to group"}` |
+| 500 Internal Server Error | Server error | `{"error": "Failed to add permission to group"}` |
+
+#### Example Request
+
+```bash
+curl -X POST http://localhost:8080/api/groups/550e8400-e29b-41d4-a716-446655440000/permissions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "permission_id": "perm-uuid-123"
+  }'
+```
+
+---
+
+### Remove Permission From Group Endpoint
+
+#### Overview
+Removes a permission from a group, revoking that permission from all users who have it through this group membership. Users may still retain the permission through other group memberships.
+
+#### Endpoint Details
+
+**URL:** `DELETE /api/groups/:id/permissions/:permissionId`  
+**Authentication:** Required (JWT Bearer token)  
+**Required Permission:** `groups:write`
+
+#### URL Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `id` | UUID | **Yes** | Group ID |
+| `permissionId` | UUID | **Yes** | Permission ID to remove from the group |
+
+#### Response
+
+**Success Response (204 No Content):**
+No response body.
+
+**Error Responses:**
+
+| Status Code | Description | Response Body |
+|-------------|-------------|---------------|
+| 400 Bad Request | Missing IDs | `{"error": "Group ID is required"}` / `{"error": "Permission ID is required"}` |
+| 401 Unauthorized | Missing or invalid token | `{"error": "Unauthorized"}` |
+| 403 Forbidden | Insufficient permissions | `{"error": "Insufficient permissions"}` |
+| 404 Not Found | Group, permission not found, or not assigned | `{"error": "Group not found"}` / `{"error": "Permission not found"}` / `{"error": "Permission not assigned to group"}` |
+| 500 Internal Server Error | Server error | `{"error": "Failed to remove permission from group"}` |
+
+#### Example Request
+
+```bash
+curl -X DELETE http://localhost:8080/api/groups/550e8400-e29b-41d4-a716-446655440000/permissions/perm-uuid-123 \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -165,6 +165,12 @@ func setupRoutes(
 
 		// Delete group (DELETE /api/groups/:id)
 		protectedGroups.DELETE("/:id", groupHandler.DeleteGroup)
+
+		// Add permission to group (POST /api/groups/:id/permissions)
+		protectedGroups.POST("/:id/permissions", groupHandler.AddPermissionToGroup)
+
+		// Remove permission from group (DELETE /api/groups/:id/permissions/:permissionId)
+		protectedGroups.DELETE("/:id/permissions/:permissionId", groupHandler.RemovePermissionFromGroup)
 	}
 
 	// Permission management endpoints (protected)

--- a/internal/models/group.go
+++ b/internal/models/group.go
@@ -33,6 +33,11 @@ type UpdateGroupRequest struct {
 	Active      *bool   `json:"active,omitempty"`
 }
 
+// AssignPermissionRequest represents the request body for assigning a permission to a group
+type AssignPermissionRequest struct {
+	PermissionID string `json:"permission_id" binding:"required"`
+}
+
 // NewGroup creates a new Group with generated UUID and timestamps
 func NewGroup(name, description string) *Group {
 	now := time.Now().Unix()


### PR DESCRIPTION
## Summary

Implements endpoints to manage the relationship between groups and permissions, enabling flexible RBAC by adding and removing permissions from groups.

## Implemented Features

### Group-Permission Assignment
- **POST /api/groups/:id/permissions** - Add permission to group
- **DELETE /api/groups/:id/permissions/:permissionId** - Remove permission from group

## Security
- Permission-based access control:
  - Both endpoints require `groups:write` permission
- JWT authentication via middleware
- Validation for group and permission existence
- Conflict detection (permission already assigned)
- Safe removal (checks if permission is assigned before removal)

## Testing
- **13 new test cases** (7 AddPermission + 6 RemovePermission)
- Table-driven tests covering:
  - Success scenarios
  - Invalid requests
  - Not found errors (group/permission)
  - Conflict scenarios (already assigned)
  - Permission checks
  - Service errors
- **Handler coverage: 86.7%** (exceeds 80% requirement)
  - AddPermissionToGroup: 87.1% coverage
  - RemovePermissionFromGroup: 85.2% coverage
- All tests passing

## Code Changes
- Added `AssignPermissionRequest` model with binding validation
- Implemented 2 handler methods with comprehensive error handling
- Leverages existing `GroupService.AddPermission()` and `RemovePermission()` methods
- Registered 2 new routes in server.go

## Documentation
- Updated API_DOCUMENTATION.md table of contents
- Added 2 complete endpoint sections:
  - Request/response schemas
  - Field descriptions
  - Error code tables
  - cURL examples

## Dependencies
- Builds on PR #98 (Group and Permission CRUD)
- Uses existing service layer methods
- No new external dependencies

Fixes #78