### PR TITLE
feat: add native TLS server mode configuration

### DIFF
--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -69,6 +69,17 @@ func TestSetupServer(t *testing.T) {
 	srv, err = SetupServer(cfg)
 	assert.Error(t, err)
 	assert.Nil(t, srv)
+
+	// Test with TLS enabled but invalid cert/key files
+	cfg = config.DefaultConfig()
+	cfg.Server.Port = 8080
+	cfg.Database.DSN = "file:test-tls.db?mode=memory&cache=shared"
+	cfg.Server.TLS.Enabled = true
+	cfg.Server.TLS.CertFile = "invalid-cert.pem"
+	cfg.Server.TLS.KeyFile = "invalid-key.pem"
+	srv, err = SetupServer(cfg)
+	assert.Error(t, err)
+	assert.Nil(t, srv)
 }
 
 func TestHandleHealthCheck(t *testing.T) {


### PR DESCRIPTION
Implements #115\n\n## Changes\n- Added TLS configuration fields under server config (, , )\n- Added environment variable parsing for , , and \n- Added TLS validation checks for required cert/key files when TLS is enabled\n- Added HTTPS startup support via  when TLS config is present\n- Added protocol-aware startup logging (/)\n- Added and updated tests for config parsing/validation and TLS setup error paths\n\n## Validation\n- runTests: internal/config/config_test.go\n- runTests: cmd/server/server_test.go\n- runTests: cmd/server/main_test.go\n\n## Notes\n- Local pre-commit Smart, fast linters runner.

Usage:
  golangci-lint [flags]
  golangci-lint [command]

Available Commands:
  cache       Cache control and information
  completion  Generate the autocompletion script for the specified shell
  config      Config file information
  custom      Build a version of golangci-lint with custom linters
  help        Help
  linters     List current linters configuration
  run         Run the linters
  version     Version

Flags:
      --color string   Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -h, --help           Help for a command
  -v, --verbose        Verbose output
      --version        Print version

Use "golangci-lint [command] --help" for more information about a command. hook is currently blocked by a local binary/version mismatch (built with Go 1.23 while repo targets Go 1.24).