### PR TITLE
fix(ci): run PR checks for release bases and base-branch edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [ main, develop, release/* ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, release/* ]
+    types: [ opened, synchronize, reopened, edited, ready_for_review ]
   workflow_dispatch:
 
 env:

--- a/docs/BRANCH_STRATEGY.md
+++ b/docs/BRANCH_STRATEGY.md
@@ -85,6 +85,11 @@ git push origin hotfix/security-jwt-validation
 
 All PRs to protected branches must pass:
 
+### 🔁 **CI Trigger Verification (PR Workflow)**
+- Open a PR targeting `release/*` and confirm CI starts automatically.
+- Change the base branch of an existing PR and confirm CI re-runs automatically.
+- Verify required status checks remain enforced for `main`, `develop`, and `release/*`.
+
 ### ✅ **Always Required**
 - **Unit Tests**: 85%+ coverage minimum
 - **Linting**: golangci-lint with strict rules


### PR DESCRIPTION
Implements #125

## Changes
- Expanded CI `pull_request.branches` to include `release/*`
- Added explicit `pull_request.types` in CI workflow:
  - `opened`
  - `synchronize`
  - `reopened`
  - `edited`
  - `ready_for_review`
- Added PR CI trigger verification checklist to `docs/BRANCH_STRATEGY.md`

## Why
- PRs targeting non-main protected branches (e.g., `release/*`) were not triggering CI.
- Changing a PR base branch did not re-trigger CI because `edited` was not included.

## Validation
- Checked workflow and docs for editor errors
- Verified focused diff contains only ticket-related changes

Closes #125
