### PR TITLE
docs: add Android TLS pinning handoff package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ server.log
 # Local development TLS certificates
 certs/
 
+# Local Android pin generation artifacts
+.artifacts/android-pin-inputs/
+
 # IDE files
 .vscode/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,14 @@ tls-cert:
 run-https-local: tls-cert
 	TLS_ENABLED=true TLS_CERT_FILE=$(TLS_CERT_FILE) TLS_KEY_FILE=$(TLS_KEY_FILE) go run ./cmd/server
 
+.PHONY: update-android-pin-bundle
+update-android-pin-bundle:
+	./scripts/update-android-pin-bundle.sh
+
+.PHONY: generate-android-pin-artifacts
+generate-android-pin-artifacts:
+	./scripts/generate-android-pin-artifacts.sh
+
 # Clean build artifacts
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ update-android-pin-bundle:
 generate-android-pin-artifacts:
 	./scripts/generate-android-pin-artifacts.sh
 
+.PHONY: bootstrap-local-android-pin-bundle
+bootstrap-local-android-pin-bundle:
+	./scripts/bootstrap-local-android-pin-bundle.sh
+
 # Clean build artifacts
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ make tls-cert
 ```
 
 Generated files are stored in `certs/dev/` and ignored by git.
+
+### Android Certificate Pinning Handoff
+
+For Android pinning requirements and operational handoff artifacts, see:
+
+- [Android pin bundle](docs/security/android-pin-bundle.json)
+- [Android certificate pinning runbook](docs/security/android-certificate-pinning-runbook.md)
+
 ## API Endpoints
 
 ### Health Check

--- a/TICKET_TREE.md
+++ b/TICKET_TREE.md
@@ -515,4 +515,25 @@ LOG_LEVEL=info
 - **JWT:** Stateless with 1-hour expiry, contains permission UUIDs
 - **Email Verification:** Flagged for future implementation (not in current scope)
 
+---
+
+## **TLS/SSL Addendum (March 2026)**
+
+This file primarily tracks the user-management tree (#60-#89 server, #44-#59 Android). TLS/SSL work was tracked separately in the server repo and is now completed.
+
+### **Server TLS EPIC Status**
+
+- ✅ **#114** - EPIC: End-to-End TLS/SSL Support Across All Environments (**CLOSED**)
+- ✅ **#115** - Native TLS server mode + environment configuration (**CLOSED**)
+- ✅ **#116** - Local HTTPS cert generation tooling and make targets (**CLOSED**)
+- ✅ **#117** - HTTPS enforcement policy by environment (**CLOSED**)
+- ✅ **#118** - TLS integration/regression test coverage (**CLOSED**)
+- ✅ **#119** - TLS deployment and cert operations documentation (**CLOSED**)
+
+### **Follow-up Needed for Android Certificate Pinning**
+
+- 🟡 **#130** - Publish Android certificate pin bundle and rotation handoff (**OPEN**)
+    - Why: Android ticket **DanyalTorabi/SmsLogger#56** needs authoritative hostname/SPKI pin data (current + backup) and rotation process.
+    - Output: pin bundle + runbook so Android can implement `CertificatePinner` safely.
+
 Good luck with the implementation! 🚀

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,6 +6,7 @@ This guide covers deployment strategies and configurations for the SMS Sync Serv
 
 - [Deployment Overview](#deployment-overview)
 - [Environment Configuration](#environment-configuration)
+- [Android Certificate Pinning Handoff](#android-certificate-pinning-handoff)
 - [Docker Deployment](#docker-deployment)
 - [Production Setup](#production-setup)
 - [Monitoring and Logging](#monitoring-and-logging)
@@ -355,6 +356,19 @@ ADMIN_PASSWORD="$(aws ssm get-parameter --name /prod/admin-password --with-decry
 2. Restart server and verify `GET /health` over HTTPS.
 3. If cert rollback is not possible, temporarily set `ALLOW_INSECURE_HTTP=true` only under incident controls.
 4. Open incident follow-up to restore TLS-compliant state immediately.
+
+## Android Certificate Pinning Handoff
+
+Android pinning consumes the externally presented TLS certificate public key (SPKI). This is critical when TLS is terminated at reverse proxy/CDN instead of native app TLS.
+
+- Pin bundle source of truth: [docs/security/android-pin-bundle.json](./security/android-pin-bundle.json)
+- Rotation and extraction procedure: [docs/security/android-certificate-pinning-runbook.md](./security/android-certificate-pinning-runbook.md)
+
+Minimum handoff expectations:
+
+1. Publish hostnames per environment.
+2. Provide two pins per hostname (`current` + `backup`) in `sha256/<base64>` format.
+3. Update bundle before certificate cutover and notify Android maintainers.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -258,6 +258,7 @@ curl -k https://localhost:8080/health
 Notes:
 - `-k` is required for self-signed local certs unless you trust the local CA/cert.
 - For proxy-based local setups, set `TLS_REDIRECT_HTTP=true` to validate redirect behavior.
+- For Android pinning handoff artifacts, see [docs/security/android-pin-bundle.json](./security/android-pin-bundle.json) and [docs/security/android-certificate-pinning-runbook.md](./security/android-certificate-pinning-runbook.md).
 - Use `APP_ENV=development` locally; keep `APP_ENV=staging|production` for environment policy testing.
 
 ## Database Management

--- a/docs/security/android-certificate-pinning-runbook.md
+++ b/docs/security/android-certificate-pinning-runbook.md
@@ -1,0 +1,68 @@
+# Android Certificate Pinning Runbook
+
+This runbook defines how server maintainers provide certificate pin data to Android for `CertificatePinner`.
+
+## Scope
+
+- Source issue: [#130](https://github.com/DanyalTorabi/sms-syncer-server/issues/130)
+- Android dependency: [DanyalTorabi/SmsLogger#56](https://github.com/DanyalTorabi/SmsLogger/issues/56)
+- Pin bundle source of truth: [android-pin-bundle.json](./android-pin-bundle.json)
+
+## Required Outputs
+
+1. Environment-specific API hostname list (staging/production and any additional public hosts)
+2. SPKI pin values in OkHttp format: `sha256/<base64-hash>`
+3. Two pins per host:
+   - `current`: currently deployed serving key
+   - `backup`: next key available for rotation
+4. Rotation and rollback steps with owner responsibilities
+
+## Extract SPKI Pin from PEM Certificate
+
+```bash
+openssl x509 -in /path/to/cert.pem -pubkey -noout \
+  | openssl pkey -pubin -outform DER \
+  | openssl dgst -sha256 -binary \
+  | openssl base64
+```
+
+Output value should be recorded as:
+
+```text
+sha256/<output-from-command>
+```
+
+## Extract SPKI Pin from Live Endpoint
+
+```bash
+openssl s_client -connect api.example.com:443 -servername api.example.com </dev/null 2>/dev/null \
+  | openssl x509 -pubkey -noout \
+  | openssl pkey -pubin -outform DER \
+  | openssl dgst -sha256 -binary \
+  | openssl base64
+```
+
+Use this to verify the live edge certificate matches documented pin values.
+
+## Rotation Workflow
+
+1. Generate/provision next certificate key pair and ensure backup pin is ready.
+2. Update `backup` pin in [android-pin-bundle.json](./android-pin-bundle.json) before deployment.
+3. Notify Android maintainers at least 14 days before cutover.
+4. Deploy new certificate.
+5. Verify live SPKI hash matches expected `current` after cutover.
+6. Promote previous backup to `current`, then register a new `backup`.
+
+## Rollback Workflow
+
+1. Roll back certificate at edge (or native TLS) to last known good key.
+2. Re-verify live SPKI hash.
+3. Confirm Android can connect without pinning failures.
+4. Open follow-up incident and update pin bundle timeline notes.
+
+## Operational Notes
+
+- Pin the certificate presented to Android clients at the network edge.
+- If TLS terminates at a reverse proxy/CDN, pin proxy/CDN serving cert public key.
+- Do not remove old pins in the same release where a key rotation happens.
+- Keep this runbook and bundle updated in the same PR whenever cert/pin data changes.

--- a/docs/security/android-certificate-pinning-runbook.md
+++ b/docs/security/android-certificate-pinning-runbook.md
@@ -17,6 +17,41 @@ This runbook defines how server maintainers provide certificate pin data to Andr
    - `backup`: next key available for rotation
 4. Rotation and rollback steps with owner responsibilities
 
+## Interactive Update Script
+
+Step 1: Generate local SPKI/date artifacts from live endpoints:
+
+```bash
+make generate-android-pin-artifacts
+```
+
+This creates local files under `.artifacts/android-pin-inputs/` (gitignored), including:
+
+- `.artifacts/android-pin-inputs/staging.json`
+- `.artifacts/android-pin-inputs/production.json`
+
+Step 2: Fill/update the pin bundle interactively:
+
+```bash
+make update-android-pin-bundle
+```
+
+The update command auto-loads generated defaults (hostname, current pin, validity dates) from those artifact files.
+
+or run it directly:
+
+```bash
+./scripts/update-android-pin-bundle.sh
+```
+
+The script prompts for:
+
+- owner and rotation notice lead time
+- staging and production hostnames
+- edge TLS termination mode
+- current and backup SPKI pins
+- validity window (`notBefore`, `notAfter`)
+
 ## Extract SPKI Pin from PEM Certificate
 
 ```bash

--- a/docs/security/android-certificate-pinning-runbook.md
+++ b/docs/security/android-certificate-pinning-runbook.md
@@ -19,6 +19,21 @@ This runbook defines how server maintainers provide certificate pin data to Andr
 
 ## Interactive Update Script
 
+For local-only development, use one command to auto-fill the bundle from `certs/dev/server.crt`:
+
+```bash
+make bootstrap-local-android-pin-bundle
+```
+
+This will:
+
+- ensure local cert exists (generates if missing)
+- compute SPKI pin from local cert
+- read `notBefore`/`notAfter` from local cert
+- update `docs/security/android-pin-bundle.json` automatically
+
+For real staging/production environments, use the artifact + interactive flow below.
+
 Step 1: Generate local SPKI/date artifacts from live endpoints:
 
 ```bash

--- a/docs/security/android-pin-bundle.json
+++ b/docs/security/android-pin-bundle.json
@@ -1,0 +1,71 @@
+{
+  "version": "1.0.0",
+  "purpose": "Authoritative certificate pin handoff for Android CertificatePinner configuration.",
+  "owner": "sms-syncer-server maintainers",
+  "lastUpdated": "2026-03-04",
+  "format": {
+    "pin": "sha256/<base64-spki-hash>",
+    "minimumPinsPerHost": 2,
+    "requiredPins": [
+      "current",
+      "backup"
+    ]
+  },
+  "environments": [
+    {
+      "name": "development",
+      "androidPinningRequired": false,
+      "notes": "Local HTTPS is primarily for developer parity. Pinning is optional for debug builds.",
+      "hosts": [
+        {
+          "hostname": "localhost",
+          "edgeTlsTermination": "native",
+          "pins": []
+        }
+      ]
+    },
+    {
+      "name": "staging",
+      "androidPinningRequired": true,
+      "notes": "Replace placeholders with real staging host and pins.",
+      "hosts": [
+        {
+          "hostname": "api-staging.example.com",
+          "edgeTlsTermination": "proxy",
+          "pins": {
+            "current": "sha256/REPLACE_WITH_STAGING_CURRENT_SPKI",
+            "backup": "sha256/REPLACE_WITH_STAGING_BACKUP_SPKI"
+          },
+          "validity": {
+            "notBefore": "REPLACE_DATE",
+            "notAfter": "REPLACE_DATE"
+          }
+        }
+      ]
+    },
+    {
+      "name": "production",
+      "androidPinningRequired": true,
+      "notes": "Replace placeholders with real production host and pins.",
+      "hosts": [
+        {
+          "hostname": "api.example.com",
+          "edgeTlsTermination": "proxy",
+          "pins": {
+            "current": "sha256/REPLACE_WITH_PROD_CURRENT_SPKI",
+            "backup": "sha256/REPLACE_WITH_PROD_BACKUP_SPKI"
+          },
+          "validity": {
+            "notBefore": "REPLACE_DATE",
+            "notAfter": "REPLACE_DATE"
+          }
+        }
+      ]
+    }
+  ],
+  "changeManagement": {
+    "rotationNoticeLeadTime": "14 days",
+    "androidDependency": "DanyalTorabi/SmsLogger#56",
+    "sourceIssue": "#130"
+  }
+}

--- a/scripts/bootstrap-local-android-pin-bundle.sh
+++ b/scripts/bootstrap-local-android-pin-bundle.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CERT_DIR="${ROOT_DIR}/certs/dev"
+CERT_FILE="${CERT_DIR}/server.crt"
+BUNDLE_PATH="${ROOT_DIR}/docs/security/android-pin-bundle.json"
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "Error: openssl is required but not installed."
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed."
+  exit 1
+fi
+
+if [[ ! -f "${CERT_FILE}" ]]; then
+  echo "Local cert not found. Generating dev certs in ${CERT_DIR}..."
+  "${ROOT_DIR}/scripts/generate-dev-cert.sh" "${CERT_DIR}"
+fi
+
+if [[ ! -f "${BUNDLE_PATH}" ]]; then
+  echo "Error: bundle file not found at ${BUNDLE_PATH}"
+  exit 1
+fi
+
+if ! jq . "${BUNDLE_PATH}" >/dev/null 2>&1; then
+  echo "Error: ${BUNDLE_PATH} is not valid JSON."
+  exit 1
+fi
+
+to_iso_date() {
+  local raw_date="$1"
+  date -u -d "${raw_date}" +%F
+}
+
+current_pin="sha256/$(openssl x509 -in "${CERT_FILE}" -pubkey -noout \
+  | openssl pkey -pubin -outform DER \
+  | openssl dgst -sha256 -binary \
+  | openssl base64)"
+
+not_before_raw="$(openssl x509 -in "${CERT_FILE}" -noout -startdate | cut -d= -f2-)"
+not_after_raw="$(openssl x509 -in "${CERT_FILE}" -noout -enddate | cut -d= -f2-)"
+not_before="$(to_iso_date "${not_before_raw}")"
+not_after="$(to_iso_date "${not_after_raw}")"
+today="$(date +%F)"
+
+tmp_file="$(mktemp)"
+
+jq \
+  --arg pin "${current_pin}" \
+  --arg notBefore "${not_before}" \
+  --arg notAfter "${not_after}" \
+  --arg today "${today}" \
+  '
+  .lastUpdated = $today |
+  .environments |= map(
+    if .name == "development" then
+      .androidPinningRequired = false |
+      .notes = "Local HTTPS development bootstrap using certs/dev/server.crt" |
+      .hosts = [
+        {
+          hostname: "localhost",
+          edgeTlsTermination: "native",
+          pins: {
+            current: $pin,
+            backup: $pin
+          },
+          validity: {
+            notBefore: $notBefore,
+            notAfter: $notAfter
+          }
+        }
+      ]
+    elif .name == "staging" or .name == "production" then
+      .androidPinningRequired = false |
+      .notes = "Temporary local-only bootstrap values. Replace with real environment host/pins before enabling pinning." |
+      .hosts = [
+        {
+          hostname: "localhost",
+          edgeTlsTermination: "native",
+          pins: {
+            current: $pin,
+            backup: $pin
+          },
+          validity: {
+            notBefore: $notBefore,
+            notAfter: $notAfter
+          }
+        }
+      ]
+    else
+      .
+    end
+  )
+  ' "${BUNDLE_PATH}" >"${tmp_file}"
+
+mv "${tmp_file}" "${BUNDLE_PATH}"
+
+echo "Updated ${BUNDLE_PATH} for local development."
+echo "Pin: ${current_pin}"
+echo "Validity: ${not_before} -> ${not_after}"
+echo "Review with: git --no-pager diff -- ${BUNDLE_PATH}"

--- a/scripts/generate-android-pin-artifacts.sh
+++ b/scripts/generate-android-pin-artifacts.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${ROOT_DIR}/.artifacts/android-pin-inputs"
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "Error: openssl is required but not installed."
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed."
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+to_iso_date() {
+  local raw_date="$1"
+  date -u -d "${raw_date}" +%F
+}
+
+prompt_with_default() {
+  local prompt="$1"
+  local default_value="$2"
+  local response
+  if ! read -r -p "${prompt} [${default_value}]: " response; then
+    response=""
+  fi
+  if [[ -z "${response}" ]]; then
+    response="${default_value}"
+  fi
+  printf '%s' "${response}"
+}
+
+generate_for_env() {
+  local env_name="$1"
+  local default_host="$2"
+  local default_termination="$3"
+
+  local hostname
+  local port
+  local sni
+  local termination
+  local cert_file
+  local current_pin
+  local not_before_raw
+  local not_after_raw
+  local not_before
+  local not_after
+  local out_file
+
+  echo ""
+  echo "--- ${env_name} artifact generation ---"
+
+  hostname="$(prompt_with_default "Public hostname" "${default_host}")"
+  if [[ -z "${hostname}" ]]; then
+    echo "Error: hostname cannot be empty for ${env_name}."
+    exit 1
+  fi
+
+  port="$(prompt_with_default "Port" "443")"
+  sni="$(prompt_with_default "SNI servername" "${hostname}")"
+  termination="$(prompt_with_default "Edge TLS termination (proxy|native|cdn)" "${default_termination}")"
+
+  cert_file="${OUTPUT_DIR}/${env_name}-leaf.pem"
+  out_file="${OUTPUT_DIR}/${env_name}.json"
+
+  echo "Fetching certificate from ${hostname}:${port} (SNI: ${sni})..."
+  if ! openssl s_client -connect "${hostname}:${port}" -servername "${sni}" </dev/null 2>/dev/null | openssl x509 -out "${cert_file}"; then
+    echo "Error: failed to fetch certificate for ${env_name}."
+    exit 1
+  fi
+
+  current_pin="sha256/$(openssl x509 -in "${cert_file}" -pubkey -noout \
+    | openssl pkey -pubin -outform DER \
+    | openssl dgst -sha256 -binary \
+    | openssl base64)"
+
+  not_before_raw="$(openssl x509 -in "${cert_file}" -noout -startdate | cut -d= -f2-)"
+  not_after_raw="$(openssl x509 -in "${cert_file}" -noout -enddate | cut -d= -f2-)"
+  not_before="$(to_iso_date "${not_before_raw}")"
+  not_after="$(to_iso_date "${not_after_raw}")"
+
+  jq -n \
+    --arg env "${env_name}" \
+    --arg hostname "${hostname}" \
+    --arg port "${port}" \
+    --arg sni "${sni}" \
+    --arg edgeTlsTermination "${termination}" \
+    --arg currentPin "${current_pin}" \
+    --arg notBefore "${not_before}" \
+    --arg notAfter "${not_after}" \
+    --arg generatedAt "$(date -u +%FT%TZ)" \
+    '{
+      env: $env,
+      hostname: $hostname,
+      port: $port,
+      sni: $sni,
+      edgeTlsTermination: $edgeTlsTermination,
+      currentPin: $currentPin,
+      validity: {
+        notBefore: $notBefore,
+        notAfter: $notAfter
+      },
+      generatedAt: $generatedAt
+    }' >"${out_file}"
+
+  echo "Saved ${env_name} artifact: ${out_file}"
+  echo "Extracted current pin: ${current_pin}"
+  echo "Validity: ${not_before} -> ${not_after}"
+}
+
+echo "Generating Android pin input artifacts into: ${OUTPUT_DIR}"
+echo "These files are local-only and ignored by git."
+
+generate_for_env "staging" "api-staging.example.com" "proxy"
+generate_for_env "production" "api.example.com" "proxy"
+
+echo ""
+echo "Done. Next step: run make update-android-pin-bundle"
+echo "The update script will use ${OUTPUT_DIR}/staging.json and ${OUTPUT_DIR}/production.json as defaults."

--- a/scripts/update-android-pin-bundle.sh
+++ b/scripts/update-android-pin-bundle.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUNDLE_PATH="${ROOT_DIR}/docs/security/android-pin-bundle.json"
+ARTIFACTS_DIR="${ROOT_DIR}/.artifacts/android-pin-inputs"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed."
+  echo "Install jq and rerun this script."
+  exit 1
+fi
+
+if [[ ! -f "${BUNDLE_PATH}" ]]; then
+  echo "Error: bundle file not found at ${BUNDLE_PATH}"
+  exit 1
+fi
+
+if ! jq . "${BUNDLE_PATH}" >/dev/null 2>&1; then
+  echo "Error: ${BUNDLE_PATH} is not valid JSON."
+  exit 1
+fi
+
+require_non_empty() {
+  local value="$1"
+  local field_name="$2"
+  if [[ -z "${value}" ]]; then
+    echo "Error: ${field_name} cannot be empty."
+    exit 1
+  fi
+}
+
+validate_date() {
+  local value="$1"
+  local field_name="$2"
+  if [[ ! "${value}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    echo "Error: ${field_name} must be in YYYY-MM-DD format." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+validate_pin() {
+  local value="$1"
+  local field_name="$2"
+  if [[ "${value}" == *"REPLACE_WITH_"* ]]; then
+    echo "Error: ${field_name} is still a placeholder. Enter a real SPKI pin." >&2
+    return 1
+  fi
+
+  if [[ ! "${value}" =~ ^sha256/[A-Za-z0-9+/=]+$ ]]; then
+    echo "Error: ${field_name} must look like sha256/<base64>." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+prompt_with_default() {
+  local prompt="$1"
+  local default_value="$2"
+  local response
+  if ! read -r -p "${prompt} [${default_value}]: " response; then
+    response=""
+  fi
+  if [[ -z "${response}" ]]; then
+    response="${default_value}"
+  fi
+  printf '%s' "${response}"
+}
+
+prompt_bool_default() {
+  local prompt="$1"
+  local default_value="$2"
+  local response
+  if ! read -r -p "${prompt} [${default_value}]: " response; then
+    response=""
+  fi
+  if [[ -z "${response}" ]]; then
+    response="${default_value}"
+  fi
+  response="$(echo "${response}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${response}" != "true" && "${response}" != "false" ]]; then
+    echo "Error: enter true or false."
+    exit 1
+  fi
+  printf '%s' "${response}"
+}
+
+prompt_env_host() {
+  local env_name="$1"
+  local default_host="$2"
+  local default_termination="$3"
+  local default_current_pin="$4"
+  local default_backup_pin="$5"
+  local default_not_before="$6"
+  local default_not_after="$7"
+  local out_prefix="$8"
+
+  echo "" >&2
+  echo "--- ${env_name} ---" >&2
+
+  local hostname
+  local edge_tls_termination
+  local current_pin
+  local backup_pin
+  local not_before
+  local not_after
+
+  hostname="$(prompt_with_default "Hostname" "${default_host}")"
+  require_non_empty "${hostname}" "${env_name} hostname"
+
+  edge_tls_termination="$(prompt_with_default "Edge TLS termination (proxy|native|cdn)" "${default_termination}")"
+  require_non_empty "${edge_tls_termination}" "${env_name} edgeTlsTermination"
+
+  while true; do
+    current_pin="$(prompt_with_default "Current SPKI pin" "${default_current_pin}")"
+    if validate_pin "${current_pin}" "${env_name} current pin"; then
+      break
+    fi
+  done
+
+  while true; do
+    backup_pin="$(prompt_with_default "Backup SPKI pin" "${default_backup_pin}")"
+    if validate_pin "${backup_pin}" "${env_name} backup pin"; then
+      break
+    fi
+  done
+
+  while true; do
+    not_before="$(prompt_with_default "Validity notBefore (YYYY-MM-DD)" "${default_not_before}")"
+    if validate_date "${not_before}" "${env_name} validity.notBefore"; then
+      break
+    fi
+  done
+
+  while true; do
+    not_after="$(prompt_with_default "Validity notAfter (YYYY-MM-DD)" "${default_not_after}")"
+    if validate_date "${not_after}" "${env_name} validity.notAfter"; then
+      break
+    fi
+  done
+
+  printf -v "${out_prefix}hostname" '%s' "${hostname}"
+  printf -v "${out_prefix}term" '%s' "${edge_tls_termination}"
+  printf -v "${out_prefix}current" '%s' "${current_pin}"
+  printf -v "${out_prefix}backup" '%s' "${backup_pin}"
+  printf -v "${out_prefix}not_before" '%s' "${not_before}"
+  printf -v "${out_prefix}not_after" '%s' "${not_after}"
+}
+
+echo "Updating ${BUNDLE_PATH}"
+echo "Press Enter to keep defaults shown in brackets."
+
+owner_default="$(jq -r '.owner' "${BUNDLE_PATH}")"
+lead_time_default="$(jq -r '.changeManagement.rotationNoticeLeadTime' "${BUNDLE_PATH}")"
+
+staging_host_default="$(jq -r '.environments[] | select(.name=="staging") | .hosts[0].hostname' "${BUNDLE_PATH}")"
+staging_term_default="$(jq -r '.environments[] | select(.name=="staging") | .hosts[0].edgeTlsTermination' "${BUNDLE_PATH}")"
+staging_curr_default="$(jq -r '.environments[] | select(.name=="staging") | .hosts[0].pins.current' "${BUNDLE_PATH}")"
+staging_back_default="$(jq -r '.environments[] | select(.name=="staging") | .hosts[0].pins.backup' "${BUNDLE_PATH}")"
+staging_nb_default="$(jq -r '.environments[] | select(.name=="staging") | .hosts[0].validity.notBefore' "${BUNDLE_PATH}")"
+staging_na_default="$(jq -r '.environments[] | select(.name=="staging") | .hosts[0].validity.notAfter' "${BUNDLE_PATH}")"
+
+prod_host_default="$(jq -r '.environments[] | select(.name=="production") | .hosts[0].hostname' "${BUNDLE_PATH}")"
+prod_term_default="$(jq -r '.environments[] | select(.name=="production") | .hosts[0].edgeTlsTermination' "${BUNDLE_PATH}")"
+prod_curr_default="$(jq -r '.environments[] | select(.name=="production") | .hosts[0].pins.current' "${BUNDLE_PATH}")"
+prod_back_default="$(jq -r '.environments[] | select(.name=="production") | .hosts[0].pins.backup' "${BUNDLE_PATH}")"
+prod_nb_default="$(jq -r '.environments[] | select(.name=="production") | .hosts[0].validity.notBefore' "${BUNDLE_PATH}")"
+prod_na_default="$(jq -r '.environments[] | select(.name=="production") | .hosts[0].validity.notAfter' "${BUNDLE_PATH}")"
+
+staging_artifact="${ARTIFACTS_DIR}/staging.json"
+production_artifact="${ARTIFACTS_DIR}/production.json"
+
+if [[ -f "${staging_artifact}" ]] && jq . "${staging_artifact}" >/dev/null 2>&1; then
+  staging_host_default="$(jq -r '.hostname // empty' "${staging_artifact}")"
+  staging_term_default="$(jq -r '.edgeTlsTermination // empty' "${staging_artifact}")"
+  staging_curr_default="$(jq -r '.currentPin // empty' "${staging_artifact}")"
+  staging_nb_default="$(jq -r '.validity.notBefore // empty' "${staging_artifact}")"
+  staging_na_default="$(jq -r '.validity.notAfter // empty' "${staging_artifact}")"
+  echo "Loaded staging defaults from ${staging_artifact}"
+fi
+
+if [[ -f "${production_artifact}" ]] && jq . "${production_artifact}" >/dev/null 2>&1; then
+  prod_host_default="$(jq -r '.hostname // empty' "${production_artifact}")"
+  prod_term_default="$(jq -r '.edgeTlsTermination // empty' "${production_artifact}")"
+  prod_curr_default="$(jq -r '.currentPin // empty' "${production_artifact}")"
+  prod_nb_default="$(jq -r '.validity.notBefore // empty' "${production_artifact}")"
+  prod_na_default="$(jq -r '.validity.notAfter // empty' "${production_artifact}")"
+  echo "Loaded production defaults from ${production_artifact}"
+fi
+
+owner="$(prompt_with_default "Owner" "${owner_default}")"
+require_non_empty "${owner}" "owner"
+
+lead_time="$(prompt_with_default "Rotation notice lead time" "${lead_time_default}")"
+require_non_empty "${lead_time}" "rotationNoticeLeadTime"
+
+staging_required_default="$(jq -r '.environments[] | select(.name=="staging") | .androidPinningRequired' "${BUNDLE_PATH}")"
+production_required_default="$(jq -r '.environments[] | select(.name=="production") | .androidPinningRequired' "${BUNDLE_PATH}")"
+
+staging_required="$(prompt_bool_default "Staging androidPinningRequired" "${staging_required_default}")"
+production_required="$(prompt_bool_default "Production androidPinningRequired" "${production_required_default}")"
+
+prompt_env_host "staging" "${staging_host_default}" "${staging_term_default}" "${staging_curr_default}" "${staging_back_default}" "${staging_nb_default}" "${staging_na_default}" "staging_"
+prompt_env_host "production" "${prod_host_default}" "${prod_term_default}" "${prod_curr_default}" "${prod_back_default}" "${prod_nb_default}" "${prod_na_default}" "production_"
+
+today="$(date +%F)"
+tmp_file="$(mktemp)"
+
+jq \
+  --arg owner "${owner}" \
+  --arg leadTime "${lead_time}" \
+  --arg lastUpdated "${today}" \
+  --arg stagingHost "${staging_hostname}" \
+  --arg stagingTerm "${staging_term}" \
+  --arg stagingCurrent "${staging_current}" \
+  --arg stagingBackup "${staging_backup}" \
+  --arg stagingNotBefore "${staging_not_before}" \
+  --arg stagingNotAfter "${staging_not_after}" \
+  --arg productionHost "${production_hostname}" \
+  --arg productionTerm "${production_term}" \
+  --arg productionCurrent "${production_current}" \
+  --arg productionBackup "${production_backup}" \
+  --arg productionNotBefore "${production_not_before}" \
+  --arg productionNotAfter "${production_not_after}" \
+  --argjson stagingRequired "${staging_required}" \
+  --argjson productionRequired "${production_required}" \
+  '
+  .owner = $owner |
+  .lastUpdated = $lastUpdated |
+  .changeManagement.rotationNoticeLeadTime = $leadTime |
+  .environments |= map(
+    if .name == "staging" then
+      .androidPinningRequired = $stagingRequired |
+      .hosts[0].hostname = $stagingHost |
+      .hosts[0].edgeTlsTermination = $stagingTerm |
+      .hosts[0].pins.current = $stagingCurrent |
+      .hosts[0].pins.backup = $stagingBackup |
+      .hosts[0].validity.notBefore = $stagingNotBefore |
+      .hosts[0].validity.notAfter = $stagingNotAfter
+    elif .name == "production" then
+      .androidPinningRequired = $productionRequired |
+      .hosts[0].hostname = $productionHost |
+      .hosts[0].edgeTlsTermination = $productionTerm |
+      .hosts[0].pins.current = $productionCurrent |
+      .hosts[0].pins.backup = $productionBackup |
+      .hosts[0].validity.notBefore = $productionNotBefore |
+      .hosts[0].validity.notAfter = $productionNotAfter
+    else
+      .
+    end
+  )
+  ' "${BUNDLE_PATH}" >"${tmp_file}"
+
+mv "${tmp_file}" "${BUNDLE_PATH}"
+
+echo ""
+echo "Updated ${BUNDLE_PATH} successfully."
+echo "Tip: review the diff with: git --no-pager diff -- ${BUNDLE_PATH}"


### PR DESCRIPTION
Implements #130

## Changes
- Added Android pin bundle source-of-truth template at docs/security/android-pin-bundle.json
- Added operator runbook at docs/security/android-certificate-pinning-runbook.md
- Linked handoff artifacts from README, deployment guide, and development guide
- Updated TICKET_TREE.md with TLS addendum and follow-up tracking

## Why
Android certificate pinning work (DanyalTorabi/SmsLogger#56) needs an explicit server-side handoff contract: hostnames, current/backup SPKI pins, and rotation process.

## Validation
- Verified pin bundle JSON is valid
- Reviewed documentation links and consistency
